### PR TITLE
add flexwrap to outer-container

### DIFF
--- a/chatapp/client/src/components/Chat.css
+++ b/chatapp/client/src/components/Chat.css
@@ -1,5 +1,6 @@
 .outerContainer {
     display: flex;
+    flex-wrap: wrap;
     justify-content: center;
     align-items: center;
     height: 100vh;


### PR DESCRIPTION
This way the text will automatically move below the chat box when the screen is too small